### PR TITLE
Buildfixes

### DIFF
--- a/2d/sdl_conf.cpp
+++ b/2d/sdl_conf.cpp
@@ -49,7 +49,8 @@ int I_ReadChocolateConfig()
 			fprintf(infile, "%s=%d\n", WindowHeightStr, WindowHeight);
 			fprintf(infile, "%s=%d\n", FitModeStr, BestFit);
 			fprintf(infile, "%s=%d\n", FullscreenStr, Fullscreen);
-			fprintf(infile, "%s=%s", SoundFontPath, SoundFontFilename);
+			if (SoundFontFilename[0])
+				fprintf(infile, "%s=%s", SoundFontPath, SoundFontFilename);
 			fclose(infile);
 		}
 		return 1;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,21 @@ if (FLUIDSYNTH_FOUND)
     )
 endif()
 
+# Set up flags for MSVC
+if (MSVC)
+	set( CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}" ) # Use all cores for compilation
+	set( CMAKE_CXX_FLAGS "/wd4267 ${CMAKE_CXX_FLAGS}" ) #warning C4267 conversion from 'size_t' to 'int', possible loss of data
+	set( CMAKE_CXX_FLAGS "/wd4244 ${CMAKE_CXX_FLAGS}" ) #warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
+	set( CMAKE_CXX_FLAGS "/wd4390 ${CMAKE_CXX_FLAGS}" ) #warning C4390: ';': empty controlled statement found; is this the intent?
+	set( CMAKE_CXX_FLAGS "/wd4101 ${CMAKE_CXX_FLAGS}" ) #warning C4101: 'org_gamma': unreferenced local variable
+	set( CMAKE_CXX_FLAGS "/wd4102 ${CMAKE_CXX_FLAGS}" ) #warning C4102: 'RePaintNewmenu4': unreferenced label
+	set( CMAKE_CXX_FLAGS "/wd4018 ${CMAKE_CXX_FLAGS}" ) #warning C4018: '>': signed/unsigned mismatch
+	set( CMAKE_CXX_FLAGS "/wd4715 ${CMAKE_CXX_FLAGS}" ) #warning C4715: 'get_num_faces': not all control paths return a value
+	set( CMAKE_CXX_FLAGS "/wd4838 ${CMAKE_CXX_FLAGS}" ) #warning C4838: conversion from 'unsigned int' to 'long' requires a narrowing conversion
+	set( CMAKE_CXX_FLAGS "/wd4309 ${CMAKE_CXX_FLAGS}" ) #warning C4309: 'argument': truncation of constant value
+	add_definitions( -D_CRT_SECURE_NO_WARNINGS=1 ) # Suppress warning about insecure strxxx functions
+endif (MSVC)
+
 #Need some additional definitions in release configuration.
 target_compile_definitions(ChocolateDescent PUBLIC "$<$<CONFIG:RELEASE>:RELEASE>")
 target_compile_definitions(ChocolateDescent2 PUBLIC "$<$<CONFIG:RELEASE>:RELEASE>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,10 @@ if (MSVC)
 	set( CMAKE_CXX_FLAGS "/wd4838 ${CMAKE_CXX_FLAGS}" ) #warning C4838: conversion from 'unsigned int' to 'long' requires a narrowing conversion
 	set( CMAKE_CXX_FLAGS "/wd4309 ${CMAKE_CXX_FLAGS}" ) #warning C4309: 'argument': truncation of constant value
 	add_definitions( -D_CRT_SECURE_NO_WARNINGS=1 ) # Suppress warning about insecure strxxx functions
+
+	# Add manifest file so that the exe declares itself as a Windows 10 exe instead of Windows XP
+	target_sources(ChocolateDescent PUBLIC "ChocolateDescent.manifest")
+	target_sources(ChocolateDescent2 PUBLIC "ChocolateDescent.manifest")
 endif (MSVC)
 
 #Need some additional definitions in release configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,12 @@ if (MSVC)
 	target_sources(ChocolateDescent2 PUBLIC "ChocolateDescent.manifest")
 endif (MSVC)
 
+# Set RELEASE define for release builds
+set( REL_CXX_FLAGS "-DRELEASE=1" )
+set( CMAKE_CXX_FLAGS_RELEASE "${REL_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}" )
+set( CMAKE_CXX_FLAGS_MINSIZEREL "${REL_CXX_FLAGS} ${CMAKE_CXX_FLAGS_MINSIZEREL}" )
+set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${REL_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" )
+
 #Need some additional definitions in release configuration.
 target_compile_definitions(ChocolateDescent PUBLIC "$<$<CONFIG:RELEASE>:RELEASE>")
 target_compile_definitions(ChocolateDescent2 PUBLIC "$<$<CONFIG:RELEASE>:RELEASE>")

--- a/ChocolateDescent.manifest
+++ b/ChocolateDescent.manifest
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
+    </dependentAssembly>
+  </dependency>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true/pm</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/main_d1/gamesave.cpp
+++ b/main_d1/gamesave.cpp
@@ -197,7 +197,7 @@ int is_real_level(char* filename)
 		return 0;
 
 	//mprintf((0, "String = [%s]\n", &filename[len-11]));
-	return !strnicmp(&filename[len - 11], "level", 5);
+	return !_strnicmp(&filename[len - 11], "level", 5);
 
 }
 

--- a/main_d1/modem.cpp
+++ b/main_d1/modem.cpp
@@ -1474,7 +1474,7 @@ setupmenu:
 
 		//mprintf((0, "%s\n", init_string));
 
-		if ((strnicmp("AT", init_string, 2)) && (strlen(init_string) < (INIT_STRING_LEN - 2)))
+		if ((_strnicmp("AT", init_string, 2)) && (strlen(init_string) < (INIT_STRING_LEN - 2)))
 			sprintf(modem_init_string, "AT%s", init_string);
 		else
 			strcpy(modem_init_string, init_string);
@@ -1608,7 +1608,7 @@ newmenu:
 		//			Netgame.game_flags |= NETGAME_FLAG_SHOW_ID;
 		if (m[options_opt].value)
 			Netgame.game_flags |= NETGAME_FLAG_SHOW_MAP;
-		if (!strnicmp(level, "s", 1))
+		if (!_strnicmp(level, "s", 1))
 			start_level_num = -atoi(level + 1);
 		else
 			start_level_num = atoi(level);

--- a/main_d1/multi.cpp
+++ b/main_d1/multi.cpp
@@ -968,7 +968,7 @@ multi_message_feedback(void)
 		{
 			for (i = 0; i < N_players; i++)
 			{
-				if (!strnicmp(Netgame.team_name[i], Network_message, colon - Network_message))
+				if (!_strnicmp(Netgame.team_name[i], Network_message, colon - Network_message))
 				{
 					if (found)
 						strcat(feedback_result, ", ");
@@ -981,7 +981,7 @@ multi_message_feedback(void)
 		}
 		for (i = 0; i < N_players; i++)
 		{
-			if ((!strnicmp(Players[i].callsign, Network_message, colon - Network_message)) && (i != Player_num) && (Players[i].connected))
+			if ((!_strnicmp(Players[i].callsign, Network_message, colon - Network_message)) && (i != Player_num) && (Players[i].connected))
 			{
 				if (found)
 					strcat(feedback_result, ", ");
@@ -1225,8 +1225,8 @@ multi_do_message(char* buf)
 	}
 	else
 	{
-		if ((!strnicmp(Players[Player_num].callsign, buf + loc, colon - (buf + loc))) ||
-			((Game_mode & GM_TEAM) && ((get_team(Player_num) == atoi(buf + loc) - 1) || !strnicmp(Netgame.team_name[get_team(Player_num)], buf + loc, colon - (buf + loc)))))
+		if ((!_strnicmp(Players[Player_num].callsign, buf + loc, colon - (buf + loc))) ||
+			((Game_mode & GM_TEAM) && ((get_team(Player_num) == atoi(buf + loc) - 1) || !_strnicmp(Netgame.team_name[get_team(Player_num)], buf + loc, colon - (buf + loc)))))
 		{
 			digi_play_sample(SOUND_HUD_MESSAGE, F1_0);
 			HUD_init_message("%s %s '%s'", Players[buf[1]].callsign, TXT_TELLS_YOU, (colon + 1));

--- a/main_d1/network.cpp
+++ b/main_d1/network.cpp
@@ -1772,7 +1772,7 @@ menu:
 		strcpy(game_name, name);
 
 
-		if (!strnicmp(slevel, "s", 1))
+		if (!_strnicmp(slevel, "s", 1))
 			* level = -atoi(slevel + 1);
 		else
 			*level = atoi(slevel);

--- a/main_d2/cntrlcen.cpp
+++ b/main_d2/cntrlcen.cpp
@@ -249,9 +249,9 @@ void do_controlcen_destroyed_stuff(object *objp)
 	if (Current_level_num < 0) {
 		int	rval;
 		#ifndef MACINTOSH
-		rval = unlink("secret.sgc");
+		rval = _unlink("secret.sgc");
 		#else
-		rval = unlink(":Players:secret.sgc");
+		rval = _unlink(":Players:secret.sgc");
 		#endif
 		mprintf((0, "Deleting secret.sgc, return value = %i\n", rval));
 	}

--- a/main_d2/gamepal.cpp
+++ b/main_d2/gamepal.cpp
@@ -112,7 +112,7 @@ int load_palette(char *name,int used_for_level,int no_change_screen)
 	if (name==NULL)
 		name = last_palette_loaded_pig;
 
-	if (used_for_level && stricmp(last_palette_loaded_pig,name) != 0) {
+	if (used_for_level && _stricmp(last_palette_loaded_pig,name) != 0) {
 
 		_splitpath(name,NULL,NULL,pigname,NULL);
 		strcat(pigname,".PIG");
@@ -125,7 +125,7 @@ int load_palette(char *name,int used_for_level,int no_change_screen)
 		#endif
 	}
 
-	if (stricmp(last_palette_loaded,name) != 0) {
+	if (_stricmp(last_palette_loaded,name) != 0) {
 
 		memcpy(old_pal,gr_palette,sizeof(old_pal));
 
@@ -157,7 +157,7 @@ int load_palette(char *name,int used_for_level,int no_change_screen)
 	}
 
 
-	if (used_for_level && stricmp(last_palette_loaded_pig,name) != 0)
+	if (used_for_level && _stricmp(last_palette_loaded_pig,name) != 0)
 	{
 		strncpy(last_palette_loaded_pig,name,sizeof(last_palette_loaded_pig));
 

--- a/main_d2/gamesave.cpp
+++ b/main_d2/gamesave.cpp
@@ -218,7 +218,7 @@ int is_real_level(char* filename)
 		return 0;
 
 	//mprintf((0, "String = [%s]\n", &filename[len-11]));
-	return !strnicmp(&filename[len - 11], "level", 5);
+	return !_strnicmp(&filename[len - 11], "level", 5);
 
 }
 #endif
@@ -316,7 +316,7 @@ void verify_object(object* obj)
 			char* name = Save_pof_names[obj->rtype.pobj_info.model_num];
 
 			for (i = 0; i < N_polygon_models; i++)
-				if (!stricmp(Pof_names[i], name)) {		//found it!	
+				if (!_stricmp(Pof_names[i], name)) {		//found it!	
 					// mprintf((0,"Mapping <%s> to %d (was %d)\n",name,i,obj->rtype.pobj_info.model_num));
 					obj->rtype.pobj_info.model_num = i;
 					break;
@@ -1675,7 +1675,7 @@ int load_level(char* filename_passed)
 #endif
 
 	strcpy(filename, filename_passed);
-	strupr(filename);
+	_strupr(filename);
 
 #ifdef EDITOR
 	//if we have the editor, try the LVL first, no matter what was passed.

--- a/main_d2/hud.cpp
+++ b/main_d2/hud.cpp
@@ -348,7 +348,7 @@ int HUD_init_message(char* format, ...)
 	// Added by Leighton 
 
 	if ((Game_mode & GM_MULTI) && FindArg("-noredundancy"))
-		if (!strnicmp("You already", message, 11))
+		if (!_strnicmp("You already", message, 11))
 			return 0;
 
 	if ((Game_mode & GM_MULTI) && FindArg("-PlayerMessages") && PlayerMessage == 0)

--- a/main_d2/inferno.cpp
+++ b/main_d2/inferno.cpp
@@ -273,7 +273,7 @@ void mem_int_to_string(int number, char* dest)
 		*p++ = buffer[i];
 	}
 	*p++ = '\0';
-	strrev(dest);
+	_strrev(dest);
 }
 
 void check_memory()

--- a/main_d2/menu.cpp
+++ b/main_d2/menu.cpp
@@ -885,7 +885,7 @@ void do_new_game_menu()
 		for (i = 0; i < n_missions; i++)
 		{
 			m[i] = Mission_list[i].mission_name;
-			if (!stricmp(m[i], config_last_mission))
+			if (!_stricmp(m[i], config_last_mission))
 				default_mission = i;
 		}
 

--- a/main_d2/mission.cpp
+++ b/main_d2/mission.cpp
@@ -179,7 +179,7 @@ char *mfgets(char *s,int n,CFILE *f)
 //compare a string for a token. returns true if match
 int istok(char *buf,char *tok)
 {
-	return strnicmp(buf,tok,strlen(tok)) == 0;
+	return _strnicmp(buf,tok,strlen(tok)) == 0;
 
 }
 
@@ -225,7 +225,7 @@ char *get_parm_value(char *parm,CFILE *f)
 
 int ml_sort_func(mle *e0,mle *e1)
 {
-	return stricmp(e0->mission_name,e1->mission_name);
+	return _stricmp(e0->mission_name,e1->mission_name);
 }
 
 extern char CDROM_dir[];
@@ -359,7 +359,7 @@ int build_mission_list(int anarchy_mode)
 	{
 		do	
 		{
-			if (stricmp(find.name,BUILTIN_MISSION)==0)
+			if (_stricmp(find.name,BUILTIN_MISSION)==0)
 				continue;		//skip the built-in
 
 			if (read_mission_file(find.name,count,ML_MISSIONDIR)) 
@@ -377,7 +377,7 @@ int build_mission_list(int anarchy_mode)
 		int i;
 
 		for (i=special_count;i<count;i++)
-			if (!stricmp(Mission_list[i].filename,"D2X")) //swap!
+			if (!_stricmp(Mission_list[i].filename,"D2X")) //swap!
 			{
 				mle temp;
 
@@ -578,7 +578,7 @@ int load_mission_by_name(char *mission_name)
 	n = build_mission_list(1);
 
 	for (i=0;i<n;i++)
-		if (!stricmp(mission_name,Mission_list[i].filename))
+		if (!_stricmp(mission_name,Mission_list[i].filename))
 			return load_mission(i);
 
 	return 0;		//couldn't find mission

--- a/main_d2/modem.cpp
+++ b/main_d2/modem.cpp
@@ -1520,7 +1520,7 @@ setupmenu:
 				
 		//mprintf((0, "%s\n", ModemInitString));
 
-		if ((strnicmp("AT", ModemInitString, 2)) && (strlen(ModemInitString) < (INIT_STRING_LEN-2)))
+		if ((_strnicmp("AT", ModemInitString, 2)) && (strlen(ModemInitString) < (INIT_STRING_LEN-2)))
 			sprintf(modem_init_string, "AT%s", ModemInitString);
 		else
 			strcpy(modem_init_string, ModemInitString);

--- a/main_d2/movie.cpp
+++ b/main_d2/movie.cpp
@@ -97,7 +97,7 @@ int HiResRoboMovie = 0;
 unsigned __cdecl FileRead(int handle, void* buf, unsigned count)
 {
 	unsigned numread;
-	numread = read(handle, buf, count);
+	numread = _read(handle, buf, count);
 	return (numread == count);
 }
 
@@ -310,7 +310,7 @@ int RunMovie(char* filename, int hires_flag, int must_have, int dx, int dy)
 #ifndef EDITOR
 		if (must_have)
 		{
-			strupr(filename);
+			_strupr(filename);
 			Error("Cannot open movie file <%s>", filename);
 		}
 		else
@@ -415,7 +415,7 @@ int RunMovie(char* filename, int hires_flag, int must_have, int dx, int dy)
 	MVE_rmEndMovie();
 	//MVE_ReleaseMem();
 
-	close(filehndl);                           // Close Movie File
+	_close(filehndl);                           // Close Movie File
 
 	//MVE_gfxReset();
 
@@ -653,7 +653,7 @@ void DeInitRobotMovie()
 
 	//MVE_palCallbacks(MVE_SetPalette);
 	MVE_palCallbacks(NULL);
-	close(RoboFile);                           // Close Movie File
+	_close(RoboFile);                           // Close Movie File
 }
 
 void __cdecl PaletteChecker(unsigned char* p, unsigned start, unsigned count)
@@ -763,7 +763,7 @@ int InitRobotMovie(char* filename)
 	MVE_palCallbacks(PaletteChecker);
 #endif
 
-	RoboFilePos = lseek(RoboFile, 0L, SEEK_CUR);
+	RoboFilePos = _lseek(RoboFile, 0L, SEEK_CUR);
 
 	mprintf((0, "RoboFilePos=%d!\n", RoboFilePos));
 	return (1);
@@ -1243,7 +1243,7 @@ void init_movies()
 	for (i = 0; i < N_BUILTIN_MOVIE_LIBS; i++) 
 	{
 
-		if (!strnicmp(movielib_files[i], "robot", 5))
+		if (!_strnicmp(movielib_files[i], "robot", 5))
 			is_robots = 1;
 		else
 			is_robots = 0;
@@ -1276,7 +1276,7 @@ int search_movie_lib(movielib * lib, char* filename, int must_have)
 		return -1;
 
 	for (i = 0; i < lib->n_movies; i++)
-		if (!stricmp(filename, lib->movies[i].name)) {	//found the movie in a library 
+		if (!_stricmp(filename, lib->movies[i].name)) {	//found the movie in a library 
 			int from_cd;
 
 			from_cd = (lib->flags & MLF_ON_CD);
@@ -1286,7 +1286,7 @@ int search_movie_lib(movielib * lib, char* filename, int must_have)
 
 			do {		//keep trying until we get the file handle
 
-				movie_handle = filehandle = open(lib->name, O_RDONLY + O_BINARY);
+				movie_handle = filehandle = _open(lib->name, O_RDONLY + O_BINARY);
 
 				if (must_have && from_cd && filehandle == -1) {		//didn't get file!
 
@@ -1297,7 +1297,7 @@ int search_movie_lib(movielib * lib, char* filename, int must_have)
 			} while (must_have && from_cd && filehandle == -1);
 
 			if (filehandle != -1)
-				lseek(filehandle, (movie_start = lib->movies[i].offset), SEEK_SET);
+				_lseek(filehandle, (movie_start = lib->movies[i].offset), SEEK_SET);
 
 			return filehandle;
 		}
@@ -1326,7 +1326,7 @@ int reset_movie_file(int handle)
 	FlipFlop = 1 - FlipFlop;
 	Assert(handle == movie_handle);
 
-	lseek(handle, movie_start, SEEK_SET);
+	_lseek(handle, movie_start, SEEK_SET);
 
 	return 0;		//everything is cool
 }

--- a/main_d2/multi.cpp
+++ b/main_d2/multi.cpp
@@ -1095,7 +1095,7 @@ multi_message_feedback(void)
 		{
 			for (i = 0; i < N_players; i++)
 			{
-				if (!strnicmp(Netgame.team_name[i], Network_message, colon-Network_message))
+				if (!_strnicmp(Netgame.team_name[i], Network_message, colon-Network_message))
 				{
 					if (found)
 						strcat(feedback_result, ", ");
@@ -1108,7 +1108,7 @@ multi_message_feedback(void)
 		}
 		for (i = 0; i < N_players; i++)
 		{
-			if ((!strnicmp(Players[i].callsign, Network_message, colon-Network_message)) && (i != Player_num) && (Players[i].connected))
+			if ((!_strnicmp(Players[i].callsign, Network_message, colon-Network_message)) && (i != Player_num) && (Players[i].connected))
 			{
 				if (found)
 					strcat(feedback_result, ", ");
@@ -1197,12 +1197,12 @@ void multi_send_message_end()
 	
 	Network_message_reciever = 100;
 
-	if (!strnicmp (Network_message,"!Names",6))
+	if (!_strnicmp (Network_message,"!Names",6))
 		{
 		 NameReturning=1-NameReturning;
 		 HUD_init_message ("Name returning is now %s.",NameReturning?"active":"disabled");
 		}
-	else if (!strnicmp (Network_message,"Handicap:",9))
+	else if (!_strnicmp (Network_message,"Handicap:",9))
 		{
 		 mytempbuf=&Network_message[9];		 
 		 mprintf ((0,"Networkhandi=%s\n",mytempbuf));
@@ -1220,9 +1220,9 @@ void multi_send_message_end()
 		 HUD_init_message ("Telling others of your handicap of %d!",StartingShields);
 		 StartingShields=i2f(StartingShields);
 		}
-	else if (!strnicmp (Network_message,"NoBombs",7))
+	else if (!_strnicmp (Network_message,"NoBombs",7))
 	 Netgame.DoSmartMine=0;
-	else if (!strnicmp (Network_message,"Ping:",5))
+	else if (!_strnicmp (Network_message,"Ping:",5))
 	 {
 	  if (Game_mode & GM_NETWORK)
 		{
@@ -1238,7 +1238,7 @@ void multi_send_message_end()
 			 }
 
 			for (i = 0; i < N_players; i++)
-  	        if ((!strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (i != Player_num) && (Players[i].connected))
+  	        if ((!_strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (i != Player_num) && (Players[i].connected))
             {
 				 PingLaunchTime=timer_get_fixed_seconds();
 				 network_send_ping (i);
@@ -1258,7 +1258,7 @@ void multi_send_message_end()
 			 return;
 	   }
 	 }												 
-	else if (!strnicmp (Network_message,"move:",5))
+	else if (!_strnicmp (Network_message,"move:",5))
 	 { 
 		mprintf ((0,"moving?\n"));
 		
@@ -1282,7 +1282,7 @@ void multi_send_message_end()
 			 }
 
 			for (i = 0; i < N_players; i++)
-  	        if ((!strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (Players[i].connected))
+  	        if ((!_strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (Players[i].connected))
             {
 				 if ((Game_mode & GM_CAPTURE) && (Players[i].flags & PLAYER_FLAGS_FLAG))
 				  {
@@ -1313,7 +1313,7 @@ void multi_send_message_end()
 	 	  }    
 	 }												 
 
-	else if (!strnicmp (Network_message,"kick:",5) && (Game_mode & GM_NETWORK))
+	else if (!_strnicmp (Network_message,"kick:",5) && (Game_mode & GM_NETWORK))
 	 {
 		int name_index=5;
 		if (strlen(Network_message) > 5)
@@ -1363,7 +1363,7 @@ void multi_send_message_end()
 
 
 		for (i = 0; i < N_players; i++)
-	    	if ((!strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (i != Player_num) && (Players[i].connected)) {
+	    	if ((!_strnicmp(Players[i].callsign, &Network_message[name_index], strlen(Network_message)-name_index)) && (i != Player_num) && (Players[i].connected)) {
 kick_player:;
   	   		if (Network_game_type == IPX_GAME)
 					network_dump_player(NetPlayers.players[i].network.ipx.server,NetPlayers.players[i].network.ipx.node, 7);
@@ -1595,8 +1595,8 @@ multi_do_message(char *buf)
 	}
 	else
 	{
-		if ( (!strnicmp(Players[Player_num].callsign, buf+loc, colon-(buf+loc))) ||
-			  ((Game_mode & GM_TEAM) && ( (get_team(Player_num) == atoi(buf+loc)-1) || !strnicmp(Netgame.team_name[get_team(Player_num)], buf+loc, colon-(buf+loc)))) )
+		if ( (!_strnicmp(Players[Player_num].callsign, buf+loc, colon-(buf+loc))) ||
+			  ((Game_mode & GM_TEAM) && ( (get_team(Player_num) == atoi(buf+loc)-1) || !_strnicmp(Netgame.team_name[get_team(Player_num)], buf+loc, colon-(buf+loc)))) )
 		{
 		   mesbuf[0] = 1;
 			mesbuf[1] = BM_XRGB(0, 32, 32);

--- a/main_d2/newdemo.cpp
+++ b/main_d2/newdemo.cpp
@@ -3030,7 +3030,7 @@ void newdemo_start_recording()
 
 	if (outfile == NULL && errno == ENOENT) //dir doesn't exist?
 	{		
-		mkdir(DEMO_DIR);								//try making directory
+		_mkdir(DEMO_DIR);								//try making directory
 		outfile = fopen(DEMO_FILENAME, "wb");
 	}
 
@@ -3303,7 +3303,7 @@ void newdemo_start_playback(char* filename)
 	Newdemo_state = ND_STATE_PLAYBACK;
 	Newdemo_vcr_state = ND_STATE_PLAYBACK;
 	Newdemo_old_cockpit = Cockpit_mode;
-	Newdemo_size = filelength(fileno(infile));
+	Newdemo_size = _filelength(_fileno(infile));
 	nd_bad_read = 0;
 	Newdemo_at_eof = 0;
 	NewdemoFrameCount = 0;

--- a/main_d2/newmenu.cpp
+++ b/main_d2/newmenu.cpp
@@ -1455,7 +1455,7 @@ RePaintNewmenu4:
 			{
 				item[choice].group = 1;
 				item[choice].redraw = 1;
-				if (!strnicmp(item[choice].saved_text, TXT_EMPTY, strlen(TXT_EMPTY)))
+				if (!_strnicmp(item[choice].saved_text, TXT_EMPTY, strlen(TXT_EMPTY)))
 				{
 					item[choice].text[0] = 0;
 					item[choice].value = -1;
@@ -1699,7 +1699,7 @@ RePaintNewmenu4:
 		if (!done && !mouse_state && omouse_state && (choice > -1) && (item[choice].type == NM_TYPE_INPUT_MENU) && (item[choice].group == 0)) {
 			item[choice].group = 1;
 			item[choice].redraw = 1;
-			if (!strnicmp(item[choice].saved_text, TXT_EMPTY, strlen(TXT_EMPTY))) {
+			if (!_strnicmp(item[choice].saved_text, TXT_EMPTY, strlen(TXT_EMPTY))) {
 				item[choice].text[0] = 0;
 				item[choice].value = -1;
 			}
@@ -2036,7 +2036,7 @@ void delete_player_saved_games(char* name)
 	for (i = 0; i < 10; i++)
 	{
 		sprintf(filename, "%s.sg%d", name, i);
-		unlink(filename);
+		_unlink(filename);
 	}
 }
 
@@ -2259,7 +2259,7 @@ ReadFileNames:
 		newmenu_file_sort(NumFiles - 1, &filenames[14]);		// Don't sort first one!
 #endif
 		for (i = 0; i < NumFiles; i++) {
-			if (!stricmp(Players[Player_num].callsign, &filenames[i * 14])) {
+			if (!_stricmp(Players[Player_num].callsign, &filenames[i * 14])) {
 #if defined(WINDOWS) || defined(MACINTOSH) 
 				dblclick_flag = 1;
 #endif
@@ -2391,7 +2391,7 @@ ReadFileNames:
 				}
 #endif
 
-					ret = unlink(name);
+					ret = _unlink(name);
 					if (player_mode)
 						* p = 0;
 

--- a/main_d2/piggy.cpp
+++ b/main_d2/piggy.cpp
@@ -238,7 +238,7 @@ bitmap_index piggy_find_bitmap(char* name)
 		* t = 0;
 
 	for (i = 0; i < Num_aliases; i++)
-		if (stricmp(name, alias_list[i].alias_name) == 0)
+		if (_stricmp(name, alias_list[i].alias_name) == 0)
 		{
 			if (t) //extra stuff for ABMs
 			{
@@ -496,7 +496,7 @@ void piggy_new_pigfile(char* pigname)
 		pigname = DEFAULT_PIGFILE_SHAREWARE;
 #endif
 
-	if (strnicmp(Current_pigfile, pigname, sizeof(Current_pigfile)) == 0)
+	if (_strnicmp(Current_pigfile, pigname, sizeof(Current_pigfile)) == 0)
 		return;         //already have correct pig
 
 	if (!Pigfile_initialized) //have we ever opened a pigfile?
@@ -1480,7 +1480,7 @@ int piggy_is_gauge_bitmap(char* base_name)
 {
 	int i;
 	for (i = 0; i < NUM_GAUGE_BITMAPS; i++) {
-		if (!stricmp(base_name, gauge_bitmap_names[i]))
+		if (!_stricmp(base_name, gauge_bitmap_names[i]))
 			return 1;
 	}
 

--- a/main_d2/playsave.cpp
+++ b/main_d2/playsave.cpp
@@ -533,7 +533,7 @@ int find_hli_entry()
 	int i;
 
 	for (i = 0; i < n_highest_levels; i++)
-		if (!stricmp(highest_levels[i].shortname, Mission_list[Current_mission_num].filename))
+		if (!_stricmp(highest_levels[i].shortname, Mission_list[Current_mission_num].filename))
 			break;
 
 	if (i == n_highest_levels) //not found.  create entry
@@ -578,7 +578,7 @@ int get_highest_level(void)
 	if (strlen(Mission_list[Current_mission_num].filename) == 0)
 	{
 		for (i = 0; i < n_highest_levels; i++)
-			if (!stricmp(highest_levels[i].shortname, "DESTSAT")) 	//	Destination Saturn.
+			if (!_stricmp(highest_levels[i].shortname, "DESTSAT")) 	//	Destination Saturn.
 				highest_saturn_level = highest_levels[i].level_num;
 	}
 #endif

--- a/main_d2/scores.cpp
+++ b/main_d2/scores.cpp
@@ -141,7 +141,7 @@ void scores_read()
 		return;
 	}
 
-	fsize = filelength(fileno(fp));
+	fsize = _filelength(_fileno(fp));
 
 	if (fsize != sizeof(all_scores))
 	{
@@ -204,7 +204,7 @@ void int_to_string(int number, char* dest)
 		*p++ = buffer[i];
 	}
 	*p++ = '\0';
-	strrev(dest);
+	_strrev(dest);
 }
 
 void scores_fill_struct(stats_info* stats)

--- a/main_d2/state.cpp
+++ b/main_d2/state.cpp
@@ -498,7 +498,7 @@ int state_save_all(int between_levels, int secret_save, char* filename_override)
 	if (secret_save && (Control_center_destroyed))
 	{
 		mprintf((0, "Deleting secret.sgb so player can't return to base level.\n"));
-		unlink(SECRETB_FILENAME);
+		_unlink(SECRETB_FILENAME);
 		return 0;
 	}
 
@@ -555,7 +555,7 @@ int state_save_all(int between_levels, int secret_save, char* filename_override)
 			if (file_exists(temp_fname))
 			{
 				mprintf((0, "Deleting file %s\n", temp_fname));
-				rval = unlink(temp_fname);
+				rval = _unlink(temp_fname);
 				Assert(rval == 0);	//	Oops, error deleting file in temp_fname.
 			}
 
@@ -587,7 +587,7 @@ int state_save_all(int between_levels, int secret_save, char* filename_override)
 			fseek(tfp, DESC_OFFSET, SEEK_SET);
 			fwrite("[autosave backup]", sizeof(char) * DESC_LENGTH, 1, tfp);
 			fclose(tfp);
-			unlink(newname);
+			_unlink(newname);
 			rename(filename, newname);
 		}
 	}
@@ -991,7 +991,7 @@ int state_save_all_sub(char* filename, char* desc, int between_levels)
 		{
 			nm_messagebox(NULL, 1, TXT_OK, "Error writing savegame.\nPossibly out of disk\nspace.");
 			fclose(fp);
-			unlink(filename);
+			_unlink(filename);
 		}
 	}
 	else
@@ -1088,7 +1088,7 @@ int state_restore_all(int in_game, int secret_restore, char* filename_override)
 				Assert(rval == 0);	//	Oops, error copying temp_fname to secret.sgc!
 			}
 			else
-				unlink(SECRETC_FILENAME);
+				_unlink(SECRETC_FILENAME);
 		}
 	}
 

--- a/misc/args.cpp
+++ b/misc/args.cpp
@@ -23,7 +23,7 @@ int FindArg(const char* s)
 	int i;
 
 	for (i = 0; i < Num_args; i++)
-		if (!stricmp(Args[i], s))
+		if (!_stricmp(Args[i], s))
 			return i;
 
 	return 0;
@@ -39,7 +39,7 @@ void InitArgs(int argc, const char** argv)
 
 	for (i = 0; i < argc; i++)
 	{
-		Args[Num_args++] = strdup(argv[i]);
+		Args[Num_args++] = _strdup(argv[i]);
 	}
 
 	//NO_DESCENT_INI	fp = fopen( "descent.ini", "rt" );		
@@ -67,7 +67,7 @@ void InitArgs(int argc, const char** argv)
 			Args[i][0] = '-';
 
 		if (Args[i][0] == '-')
-			strlwr(Args[i]);		// Convert all args to lowercase
+			_strlwr(Args[i]);		// Convert all args to lowercase
 
 		//printf( "Args[%d] = '%s'\n", i, Args[i] );
 	}

--- a/misc/hash.cpp
+++ b/misc/hash.cpp
@@ -79,7 +79,7 @@ int hashtable_getkey(char* key) {
 int hashtable_search(hashtable* ht, char* key) {
 	int i, j, k;
 
-	strlwr(key);
+	_strlwr(key);
 
 	k = hashtable_getkey(key);
 	i = 0;
@@ -88,7 +88,7 @@ int hashtable_search(hashtable* ht, char* key) {
 		j = (k + (i++)) & ht->and_mask;
 		if (ht->key[j] == NULL)
 			return -1;
-		if (!stricmp(ht->key[j], key))
+		if (!_stricmp(ht->key[j], key))
 			return ht->value[j];
 	}
 	return -1;
@@ -97,7 +97,7 @@ int hashtable_search(hashtable* ht, char* key) {
 void hashtable_insert(hashtable* ht, char* key, int value) {
 	int i, j, k;
 
-	strlwr(key);
+	_strlwr(key);
 	k = hashtable_getkey(key);
 	i = 0;
 
@@ -109,7 +109,7 @@ void hashtable_insert(hashtable* ht, char* key, int value) {
 			ht->value[j] = value;
 			return;
 		}
-		else if (!stricmp(key, ht->key[j])) {
+		else if (!_stricmp(key, ht->key[j])) {
 			return;
 		}
 	}

--- a/mve/mvelib.cpp
+++ b/mve/mvelib.cpp
@@ -383,7 +383,7 @@ static void _mvefile_free(MVEFILE *movie)
 {
     /* free the stream */
     if (movie->stream != -1)
-        close(movie->stream);
+        _close(movie->stream);
     movie->stream = -1;
 
     /* free the buffer */
@@ -425,9 +425,9 @@ static void _mvefile_free_filehandle(MVEFILE *movie)
 static int _mvefile_open(MVEFILE *file, const char *filename)
 {
 #ifdef O_BINARY
-    file->stream = open(filename, O_RDONLY | O_BINARY);
+    file->stream = _open(filename, O_RDONLY | O_BINARY);
 #else
-    file->stream = open(filename, O_RDONLY);
+    file->stream = _open(filename, O_RDONLY);
 #endif
     if (file->stream == -1)
         return 0;
@@ -469,7 +469,7 @@ static int _mvefile_read_header(MVEFILE *movie)
         return 0;
 
     /* check the file is long enough */
-    if (read(movie->stream, buffer, 26) < 26)
+    if (_read(movie->stream, buffer, 26) < 26)
         return 0;
 
     /* check the signature */
@@ -526,7 +526,7 @@ static int _mvefile_fetch_next_chunk(MVEFILE *movie)
         return 0;
 
     /* fail if we can't read the next segment descriptor */
-    if (read(movie->stream, buffer, 4) < 4)
+    if (_read(movie->stream, buffer, 4) < 4)
         return 0;
 
     /* pull out the next length */
@@ -536,7 +536,7 @@ static int _mvefile_fetch_next_chunk(MVEFILE *movie)
     _mvefile_set_buffer_size(movie, length);
 
     /* read the chunk */
-    if (read(movie->stream, movie->cur_chunk, length) < length)
+    if (_read(movie->stream, movie->cur_chunk, length) < length)
         return 0;
     movie->cur_fill = length;
     movie->next_segment = 0;

--- a/platform/s_midi.cpp
+++ b/platform/s_midi.cpp
@@ -203,6 +203,7 @@ int S_InitMusic(int device)
 	{
 	case _MIDI_GEN:
 	{
+#ifdef USE_FLUIDSYNTH
 		MidiFluidSynth* fluidSynth = new MidiFluidSynth();
 		if (fluidSynth == nullptr)
 		{
@@ -211,6 +212,9 @@ int S_InitMusic(int device)
 		}
 		fluidSynth->SetSoundfont(SoundFontFilename);
 		synth = (MidiSynth*)fluidSynth;
+#else
+		synth = new DummyMidiSynth();
+#endif
 	}
 		break;
 	}

--- a/platform/s_midi.h
+++ b/platform/s_midi.h
@@ -98,6 +98,16 @@ public:
 	virtual void Shutdown() = 0;
 };
 
+class DummyMidiSynth : public MidiSynth
+{
+public:
+	int ClassifySynth() override { return MIDISYNTH_SOFT; }
+	void DoMidiEvent(midievent_t* ev) override { }
+	void RenderMIDI(int numTicks, int samplesPerTick, unsigned short* buffer) override { }
+	void StopSound() override { }
+	void Shutdown() override { }
+};
+
 //Class which represents the midi thread. Has a Sequencer and a Synthesizer, and invokes the current audio backend to run
 class MidiPlayer
 {

--- a/platform/win32/win32audio.cpp
+++ b/platform/win32/win32audio.cpp
@@ -488,8 +488,20 @@ void I_StopHQSong()
 	music.playing = false;
 }
 
-//[ISB] Okay I'll confess, I'm not quite sure what to do here. Ugh
-void I_StartMIDISong(hmpheader_t* song, bool loop)
+bool I_CanQueueMusicBuffer()
+{
+	return false;
+}
+
+void I_DequeueMusicBuffers()
+{
+}
+
+void I_QueueMusicBuffer(int numTicks, uint16_t* data)
+{
+}
+
+void I_StartMIDISong()
 {
 }
 
@@ -498,6 +510,26 @@ void I_StopMIDISong()
 }
 
 void I_SetMusicVolume(int volume)
+{
+}
+
+void I_InitMovieAudio(int format, int samplerate, int stereo)
+{
+}
+
+void I_QueueMovieAudioBuffer(int len, short* data)
+{
+}
+
+void I_DestroyMovieAudio()
+{
+}
+
+void I_PauseMovieAudio()
+{
+}
+
+void I_UnPauseMovieAudio()
 {
 }
 


### PR DESCRIPTION
Adds support for building without fluidsynth.
Adds manifest file to executables.
Suppresses most warnings caused by the original parallax coding style.
Adds the RELEASE define for release builds (so the debug menus aren't there).
Fixes an empty string bug when writing the first chocolatedescent.cfg file.